### PR TITLE
update migration file to remove usage of owner

### DIFF
--- a/hasura/migrations/1601667241747_chinook_db_and_data/up.sql
+++ b/hasura/migrations/1601667241747_chinook_db_and_data/up.sql
@@ -23784,8 +23784,7 @@ BEGIN
 END $BODY$
   LANGUAGE plpgsql VOLATILE
   COST 100;
-ALTER FUNCTION last_updated()
-  OWNER TO postgres;
+
 
 
 -- ----------------------------


### PR DESCRIPTION
Assigning owner role in the migration file is causing issues while using databases like Heroku Postgres addon. Removing that fixes it.